### PR TITLE
boolean context @each macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Each
-A simple function to iterate over elements in a collection or a single element, even if that single element would normally be iterable by itself. The name is chosen for the mnemonic "for each `a` of Type `T` in `collection`" => `for a in each(T, collection)`
+A simple function to iterate over elements in a collection or a single element, even if that single element would normally be iterable by itself. The name is chosen for the mnemonic "for each `a` of Type `T` in `collection`" => `for a in each(T, collection)` Each can also be used in contexts where a boolean is anticipated as a return via the macro @each.
 
 ## Example
+### each()
 ```julia
 julia>  function printstrings_without_each(a)
             for s in a
@@ -35,4 +36,24 @@ julia>  printstrings_without_each((1,2))
 2
 julia>  printstrings_with_each((1,2))
 ERROR: Tuple{Int64,Int64} does not contain elements of type String
+```
+### @each
+```julia
+x = [5, 10, 15, 20]
+if @each x % 5 == 0
+   println("They are!")
+end
+
+They are!
+
+if @each x > 25
+    println("They are!")
+end
+
+
+if @each x < 25
+    println("They are!")
+end
+
+They are!
 ```

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,0 +1,102 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.7.1"
+manifest_format = "2.0"
+
+[[deps.ANSIColoredPrinters]]
+git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"
+uuid = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"
+version = "0.0.1"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[deps.DocStringExtensions]]
+deps = ["LibGit2"]
+git-tree-sha1 = "b19534d1895d702889b219c382a6e18010797f0b"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.8.6"
+
+[[deps.Documenter]]
+deps = ["ANSIColoredPrinters", "Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
+git-tree-sha1 = "75c6cf9d99e0efc79b724f5566726ad3ad010a01"
+uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+version = "0.27.12"
+
+[[deps.Each]]
+git-tree-sha1 = "cdce2be1b4c4ef7852bdf8f7363112721509a81e"
+repo-rev = "master"
+repo-url = "https://github.com/gustaphe/Each.jl.git"
+uuid = "a463d3bb-408a-45f3-8832-4f25bdc04b78"
+version = "0.1.0"
+
+[[deps.IOCapture]]
+deps = ["Logging", "Random"]
+git-tree-sha1 = "f7be53659ab06ddc986428d3a9dcc95f6fa6705a"
+uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
+version = "0.2.2"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[deps.JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "8076680b162ada2a031f707ac7b4953e30667a37"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.2"
+
+[[deps.LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[deps.Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[deps.Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[deps.Parsers]]
+deps = ["Dates"]
+git-tree-sha1 = "92f91ba9e5941fc781fecf5494ac1da87bdac775"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "2.2.0"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[deps.REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[deps.Random]]
+deps = ["SHA", "Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,7 @@
+name = "docs"
+authors = ["David Gustavsson <david.e.gustavsson@gmail.com> and contributors"]
+version = "0.1.0"
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Each = "a463d3bb-408a-45f3-8832-4f25bdc04b78"
+

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,45 @@
+# Each.jl
+A collection of simple functions to iterate over elements in a collection or a single
+element, even if that single element would normally be iterable by itself.
+The name is chosen for the mnemonic "for each a of Type T in collection" => for
+ a in each(T, collection).
+
+## Using each in iterative contexts
+Iterates over any type of collection, type or data-structure.
+```@eval
+function printstrings_without_each(a)
+   for s in a
+      println(s)
+      end
+end
+
+function printstrings_with_each(a)
+   for s in each(String,a)
+      println(s)
+   end
+end
+
+printstrings_without_each(("apples","oranges"))
+
+printstrings_with_each(("apples","oranges"))
+
+printstrings_without_each("apples")
+```
+
+```@docs
+each
+```
+## Using each in conditional contexts
+In order to use each in a conditional contexts, we instead call to the macro
+@each. We can do so inside of any statement that expects a boolean in return.
+```@eval
+using Each
+x = [5, 10, 15]
+if @each x % 5 < 0
+   println("Each value in $x is less than 0.")
+end
+```
+
+```@docs
+@each
+```

--- a/docs/src/make.jl
+++ b/docs/src/make.jl
@@ -1,0 +1,15 @@
+using Documenter, Each
+Documenter.makedocs(root = "../",
+       source = "src",
+       build = "build",
+       clean = true,
+       doctest = true,
+       modules = [Each],
+       repo = "https://github.com/gustaphe/Each.jl",
+       highlightsig = true,
+       sitename = "Each.jl",
+       expandfirst = [],
+       pages = [
+               "Each.jl" => "index.md",
+               ]
+       )

--- a/src/Each.jl
+++ b/src/Each.jl
@@ -1,7 +1,7 @@
 module Each
+using Base.Meta
 
-
-export each
+export each, @each
 
 """
     each(Type, collection)
@@ -75,5 +75,43 @@ function each(::Type{T}, collection) where T
 end
 
 each(::Type{T}, element::T) where T = (element,)
+
+"""
+## @each exp::Expr -> ::Bool
+Determines whether each element of an iterable meets a certain condition. Returns a boolean, true if all of the elements meet a condition, false if otherwise. 
+Used in conditional contexts.
+### example
+```
+x = [5, 10, 15, 20]
+if @each x % 5 == 0
+   println("They are!")
+end
+
+They are!
+
+if @each x > 25
+    println("They are!")
+end
+
+
+if @each x < 25
+    println("They are!")
+end
+
+They are!
+```
+"""
+macro each(exp::Expr)
+    strexpr = string(exp)
+    comp = split(strexpr, ' ')
+    for value in eval(Meta.parse(string(comp[1])))
+        to_parse = string(value, " ", comp[2], " ", comp[3])
+        state = eval(Meta.parse(to_parse))
+        if state != true
+            return(false)
+        end
+    end
+    return(true)
+end
 
 end # Module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,18 @@ using Each
 using Test
 
 @testset "Each.jl" begin
-    @test sum.(each(Tuple{Vararg{Number}},((1,1),(1,2),(1,3)))) == (2,3,4)
-    @test sum.(each(Tuple{Vararg{Number}},(1,1))) == (2,)
-    @test_throws ErrorException each(String,((1,2),(3,4)))
-    @test eltype(each(String,"something")) == String
+    @testset "each()" begin
+        @test sum.(each(Tuple{Vararg{Number}},((1,1),(1,2),(1,3)))) == (2,3,4)
+        @test sum.(each(Tuple{Vararg{Number}},(1,1))) == (2,)
+        @test_throws ErrorException each(String,((1,2),(3,4)))
+        @test eltype(each(String,"something")) == String
+    end
+    @testset "@each" begin
+        x = [5, 10, 15, 20]
+        @test @each x > 0 == true
+        @test @each x < 0 == false
+        @test @each x % 5 == true
+        @test @each x == 5 == false
+    end
+    
 end


### PR DESCRIPTION
I added a new macro, some documentation, information to the README, and of course some tests for the new macro. Some notable future improvements should be the ability to use a method call, which is partially implemented, perhaps I will finish that soon. For now, however, it only really works with bit-wise bool operators. Furthermore, it would be nice to be able to provide more arguments. Here are some examples of using the macro:
```
if Main.Each.@each [5, 10, 15] < 20
    println("yeah")
end
yeah
if Main.Each.@each x > 20
    println("yeah")
end
```